### PR TITLE
Remove parameters in `ApplicationRunner` methods `runBootstrap()` and  `checkEvents()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.0.0 under development
 
+- Сhg #37: Remove parameters in `ApplicationRunner` methods `runBootstrap()` and `checkEvents()`, instead are used 
+  internal container and config instances (@vjik) 
 - Chg #36: Add ability to configure container configuration group (@vjik)
 
 ## 1.2.1 November 07, 2022

--- a/src/ApplicationRunner.php
+++ b/src/ApplicationRunner.php
@@ -116,23 +116,23 @@ abstract class ApplicationRunner implements RunnerInterface
     /**
      * @throws ErrorException|RuntimeException
      */
-    protected function runBootstrap(ConfigInterface $config, ContainerInterface $container): void
+    protected function runBootstrap(): void
     {
         if ($this->bootstrapGroup !== null) {
-            (new BootstrapRunner($container, $config->get($this->bootstrapGroup)))->run();
+            (new BootstrapRunner($this->getContainer(), $this->getConfig()->get($this->bootstrapGroup)))->run();
         }
     }
 
     /**
      * @throws ContainerExceptionInterface|ErrorException|NotFoundExceptionInterface
      */
-    protected function checkEvents(ConfigInterface $config, ContainerInterface $container): void
+    protected function checkEvents(): void
     {
         if ($this->debug && $this->eventsGroup !== null) {
             /** @psalm-suppress MixedMethodCall */
-            $container
+            $this->getContainer()
                 ->get(ListenerConfigurationChecker::class)
-                ->check($config->get($this->eventsGroup));
+                ->check($this->getConfig()->get($this->eventsGroup));
         }
     }
 

--- a/tests/ApplicationRunnerTest.php
+++ b/tests/ApplicationRunnerTest.php
@@ -124,7 +124,7 @@ final class ApplicationRunnerTest extends TestCase
 
         $this->expectOutputString('Bootstrapping');
 
-        $runner->runBootstrap($this->createConfig(), $this->createContainer());
+        $runner->runBootstrap();
     }
 
     public function testCheckEvents(): void
@@ -135,7 +135,7 @@ final class ApplicationRunnerTest extends TestCase
 
         $this->expectException(InvalidListenerConfigurationException::class);
 
-        $runner->checkEvents($config, $container);
+        $runner->checkEvents();
     }
 
     public function testRun(): void

--- a/tests/Support/ApplicationRunner/ApplicationRunner.php
+++ b/tests/Support/ApplicationRunner/ApplicationRunner.php
@@ -24,14 +24,14 @@ final class ApplicationRunner extends \Yiisoft\Yii\Runner\ApplicationRunner
         $this->checkEvents($config, $container);
     }
 
-    public function runBootstrap(ConfigInterface $config = null, ContainerInterface $container = null): void
+    public function runBootstrap(): void
     {
-        parent::runBootstrap($config, $container);
+        parent::runBootstrap();
     }
 
-    public function checkEvents(ConfigInterface $config = null, ContainerInterface $container = null): void
+    public function checkEvents(): void
     {
-        parent::checkEvents($config, $container);
+        parent::checkEvents();
     }
 
     public function getConfig(): ConfigInterface

--- a/tests/Support/ApplicationRunner/ApplicationRunner.php
+++ b/tests/Support/ApplicationRunner/ApplicationRunner.php
@@ -24,12 +24,12 @@ final class ApplicationRunner extends \Yiisoft\Yii\Runner\ApplicationRunner
         $this->checkEvents($config, $container);
     }
 
-    public function runBootstrap(ConfigInterface $config, ContainerInterface $container): void
+    public function runBootstrap(ConfigInterface $config = null, ContainerInterface $container = null): void
     {
         parent::runBootstrap($config, $container);
     }
 
-    public function checkEvents(ConfigInterface $config, ContainerInterface $container): void
+    public function checkEvents(ConfigInterface $config = null, ContainerInterface $container = null): void
     {
         parent::checkEvents($config, $container);
     }

--- a/tests/Support/ApplicationRunner/ApplicationRunner.php
+++ b/tests/Support/ApplicationRunner/ApplicationRunner.php
@@ -20,8 +20,8 @@ final class ApplicationRunner extends \Yiisoft\Yii\Runner\ApplicationRunner
     {
         $config = $this->getConfig();
         $container = $this->getContainer();
-        $this->runBootstrap($config, $container);
-        $this->checkEvents($config, $container);
+        $this->runBootstrap();
+        $this->checkEvents();
     }
 
     public function runBootstrap(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
